### PR TITLE
critical bug fixed: no component subpackage in imports and htl-use

### DIFF
--- a/src/com/senn/aem/plugin/intellij/compgen/ComponentConfig.java
+++ b/src/com/senn/aem/plugin/intellij/compgen/ComponentConfig.java
@@ -101,9 +101,7 @@ public class ComponentConfig {
 
     public String getFullyQualifiedSlingModelName() {
         String pkg = getPackageName();
-        if(StringUtils.isNotBlank(pkg)) {
-            pkg += ".";
-        }
+        pkg += "." + getShortComponentName() + "."; //always add subpackage for component
         return pkg + getSlingModelName();
     }
 


### PR DESCRIPTION
A critical bug was introduced in the code that fixed #7 (merged in #10).  Fixed in commit a62f3ba